### PR TITLE
Improve ChromeDriver configuration guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ token.json
 credentials.json
 webdriver/
 chromedriver
+config.toml

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ python main.py 2023-09-01 2023-09-30 \
 - `--output` でCSVの出力先を指定できます (既定値: `orders.csv`)。
 - `--cookies` はAmazonセッションの保存先ファイルを指定します。
 - `--credentials` はGmail APIのクライアントシークレットファイル、`--token` はアクセストークンの保存先です。
+- `--config` で設定値を記述したTOMLファイルを指定できます (既定値: `config.toml`)。
+- `--chrome-driver` で既にダウンロード済みのChromeDriverバイナリを指定できます。
+
+### config.toml での設定 (任意)
+
+リポジトリには `config.example.toml` を用意しています。必要に応じてコピーして `config.toml` を作成し、以下のように値を編集すると毎回のコマンド入力を簡略化できます。
+
+```toml
+[amazon]
+chrome_driver = "C:/tools/chromedriver.exe"
+```
+
+- `config.toml` を別の場所に置きたい場合は、`python main.py --config path/to/config.toml` のようにファイルパスを指定してください。
+- コマンドライン引数 (`--chrome-driver` など) は設定ファイルの値よりも優先されます。一時的に上書きしたい場合に便利です。
 
 実行後、指定したCSVファイルに次の列が出力されます。
 
@@ -83,6 +97,11 @@ python main.py 2023-09-01 2023-09-30 \
 
 - Amazonのページ構造は変更される可能性があります。レイアウト変更により要素が取得できなくなった場合は、`order_sync/amazon.py` のセレクタを調整してください。
 - `webdriver-manager` がブラウザドライバーをダウンロードするため、初回実行時にインターネット接続が必要です。
+- Windows 32bit 環境や企業ネットワークなど、`webdriver-manager` が互換性のあるChromeDriverを取得できない場合は手動でドライバーを用意してください。
+  1. 使用しているChromeのバージョンを確認し、[Chrome for Testing (ChromeDriver) の公式ダウンロードページ](https://googlechromelabs.github.io/chrome-for-testing/) から対応するバージョンとプラットフォームのアーカイブを取得します。
+  2. アーカイブを解凍し、`chromedriver`（Windowsでは `chromedriver.exe`）を任意のフォルダーに配置します。
+  3. `config.example.toml` を `config.toml` にコピーし、`amazon.chrome_driver` に配置したファイルへのパスを記述します（例: `chrome_driver = "C:/tools/chromedriver.exe"`）。
+  4. 一時的に別のバイナリを使いたい場合は、実行時に `--chrome-driver` オプションでパスを上書きできます（例: `python main.py 2023-09-01 2023-09-30 --chrome-driver C:\\tools\\chromedriver.exe`）。
 - Gmailの検索は最大5件のメールを対象にしています。必要に応じて `order_sync/gmail_client.py` の `find_status` 内で調整してください。
 - 取得したCSVには個人情報が含まれるため、適切に管理・保管してください。
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,6 @@
+# config.toml のサンプルです。必要に応じてこのファイルをコピーして config.toml を作成し、値を編集してください。
+
+[amazon]
+# 既にダウンロード済みの ChromeDriver バイナリへのパス
+# Windows でバックラッシュを含む場合は "C:/tools/chromedriver.exe" のようにスラッシュで指定するか、\\ を二重にしてください。
+chrome_driver = "C:/tools/chromedriver.exe"

--- a/order_sync/amazon.py
+++ b/order_sync/amazon.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 from dateutil import parser as date_parser
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
+from selenium.common.exceptions import WebDriverException
 from webdriver_manager.chrome import ChromeDriverManager
 
 from .models import Order, OrderItem
@@ -23,6 +24,7 @@ class AmazonConfig:
     base_url: str = "https://www.amazon.co.jp"
     orders_url: str = "https://www.amazon.co.jp/gp/your-account/order-history"
     wait_seconds: float = 3.0
+    driver_path: Path | None = None
 
 
 class AmazonOrderFetcher:
@@ -34,10 +36,38 @@ class AmazonOrderFetcher:
     def _create_driver(self) -> webdriver.Chrome:
         options = webdriver.ChromeOptions()
         options.add_argument("--start-maximized")
-        driver = webdriver.Chrome(
-            service=Service(ChromeDriverManager().install()),
-            options=options,
+        driver_binary = (
+            Path(self.config.driver_path)
+            if self.config.driver_path is not None
+            else Path(ChromeDriverManager().install())
         )
+        if not driver_binary.exists():
+            raise RuntimeError(
+                "指定された ChromeDriver が見つかりませんでした。"
+                f"パスを確認してください: {driver_binary}"
+            )
+        try:
+            driver = webdriver.Chrome(
+                service=Service(str(driver_binary)),
+                options=options,
+            )
+        except (OSError, WebDriverException) as exc:
+            if self.config.driver_path is None:
+                guidance = (
+                    "自動ダウンロードされたバイナリが環境に対応していない可能性があります。"
+                    "ChromeDriver を手動でダウンロードし、AmazonConfig.driver_path もしくは "
+                    "--chrome-driver オプションでパスを指定してください。"
+                )
+            else:
+                guidance = (
+                    "指定された ChromeDriver が実行環境や Chrome のバージョンに対応しているか確認してください。"
+                )
+            raise RuntimeError(
+                "ChromeDriver の起動に失敗しました。\n"
+                f"使用したバイナリ: {driver_binary}\n"
+                f"{guidance}\n"
+                f"詳細: {exc}"
+            ) from exc
         return driver
 
     def _load_cookies(self, driver: webdriver.Chrome) -> None:

--- a/order_sync/cli.py
+++ b/order_sync/cli.py
@@ -3,33 +3,44 @@ from __future__ import annotations
 import argparse
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Sequence
+
+import tomllib
 
 from .amazon import AmazonConfig, AmazonOrderFetcher
 from .csv_writer import CsvWriter
 from .gmail_client import GmailClient, GmailConfig, StatusDetector
 from .processing import OrderProcessor
 
+DATE_FORMAT = "%Y-%m-%d"
+DEFAULT_CONFIG_FILE = Path("config.toml")
 
-def parse_args() -> argparse.Namespace:
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Amazon注文とGmail通知をCSVにエクスポートします。",
         epilog="開始日と終了日を指定しなかった場合は、実行時に入力を求めます。",
     )
     parser.add_argument(
+        "start_date",
+        nargs="?",
+        help="取得開始日 (YYYY-MM-DD)。省略すると実行時に入力できます。",
+    )
+    parser.add_argument(
+        "end_date",
+        nargs="?",
+        help="取得終了日 (YYYY-MM-DD)。省略すると実行時に入力できます。",
+    )
+    parser.add_argument(
         "--start-date",
-        dest="start_date",
-        help="取得開始日 (YYYY-MM-DD)。指定しない場合は起動後に入力できます。",
+        dest="start_date_override",
+        help="取得開始日 (YYYY-MM-DD)。引数で指定しない場合は実行時に入力できます。",
     )
     parser.add_argument(
         "--end-date",
-        dest="end_date",
-        help="取得終了日 (YYYY-MM-DD)。指定しない場合は起動後に入力できます。",
+        dest="end_date_override",
+        help="取得終了日 (YYYY-MM-DD)。引数で指定しない場合は実行時に入力できます。",
     )
-
-    parser = argparse.ArgumentParser(description="Amazon注文とGmail通知をCSVにエクスポートします。")
-    parser.add_argument("start_date", help="取得開始日 (YYYY-MM-DD)")
-    parser.add_argument("end_date", help="取得終了日 (YYYY-MM-DD)")
-
     parser.add_argument(
         "--output",
         type=Path,
@@ -54,8 +65,53 @@ def parse_args() -> argparse.Namespace:
         default=Path("token.json"),
         help="Gmail APIのアクセストークン保存ファイル",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_FILE,
+        help="設定値を上書きするTOMLファイル (デフォルト: config.toml)",
+    )
+    parser.add_argument(
+        "--chrome-driver",
+        dest="chrome_driver",
+        type=Path,
+        default=None,
+        help="既存のChromeDriverバイナリへのパス (指定すると自動ダウンロードをスキップ)",
+    )
+    return parser.parse_args(argv)
 
+
+def _load_settings(config_file: Path) -> dict[str, Any]:
+    if not config_file.exists():
+        return {}
+    try:
+        with config_file.open("rb") as handle:
+            return tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:  # pragma: no cover - config errors exit early
+        raise SystemExit(
+            f"設定ファイルの読み込みに失敗しました ({config_file}): {exc}"
+        ) from exc
+
+
+def _get_path_setting(
+    settings: dict[str, Any], config_file: Path, *keys: str
+) -> Path | None:
+    if not settings:
+        return None
+
+    node: Any = settings
+    for key in keys:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+
+    if node in (None, ""):
+        return None
+
+    path = Path(str(node)).expanduser()
+    if not path.is_absolute():
+        path = (config_file.parent / path).expanduser()
+    return path
 
 
 def _resolve_date(initial: str | None, label: str) -> datetime:
@@ -68,30 +124,38 @@ def _resolve_date(initial: str | None, label: str) -> datetime:
             value = None
             continue
         try:
-            return datetime.strptime(value, "%Y-%m-%d")
+            return datetime.strptime(value, DATE_FORMAT)
         except ValueError:
             print("日付の形式が正しくありません。例: 2023-09-01")
             value = None
 
 
-def main() -> None:
-    args = parse_args()
-    start = _resolve_date(args.start_date, "開始日")
-    end = _resolve_date(args.end_date, "終了日")
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    start_input = args.start_date_override or args.start_date
+    end_input = args.end_date_override or args.end_date
+
+    start = _resolve_date(start_input, "開始日")
+    end = _resolve_date(end_input, "終了日")
 
     while end < start:
         print("終了日は開始日以降の日付を入力してください。再入力します。")
         start = _resolve_date(None, "開始日")
         end = _resolve_date(None, "終了日")
 
-def main() -> None:
-    args = parse_args()
-    start = datetime.strptime(args.start_date, "%Y-%m-%d")
-    end = datetime.strptime(args.end_date, "%Y-%m-%d")
+    settings = _load_settings(args.config)
+    driver_path = args.chrome_driver or _get_path_setting(
+        settings, args.config, "amazon", "chrome_driver"
+    )
 
-
-    amazon_config = AmazonConfig(cookie_file=args.cookies)
-    gmail_config = GmailConfig(credentials_file=args.credentials, token_file=args.token)
+    amazon_config = AmazonConfig(
+        cookie_file=args.cookies,
+        driver_path=driver_path,
+    )
+    gmail_config = GmailConfig(
+        credentials_file=args.credentials,
+        token_file=args.token,
+    )
 
     amazon_fetcher = AmazonOrderFetcher(config=amazon_config)
     gmail_client = GmailClient(config=gmail_config)


### PR DESCRIPTION
## Summary
- allow AmazonConfig to accept an optional ChromeDriver path and surface a clearer error when the bundled binary is incompatible
- add a --chrome-driver CLI argument that passes the path through to AmazonConfig
- document how to download ChromeDriver manually and invoke the tool with the new option
- include the binary path and original error message when ChromeDriver fails to launch, with guidance for both auto-download and manual configurations
- support loading the ChromeDriver path from config.toml, add a sample config file, and update the docs to prefer configuration-based overrides

## Testing
- python -m compileall order_sync

------
https://chatgpt.com/codex/tasks/task_e_68de1f2bf4dc832f9dcecc27c269f424